### PR TITLE
Arreglo de errores

### DIFF
--- a/Assets/Scenes/LoginUserScene.unity
+++ b/Assets/Scenes/LoginUserScene.unity
@@ -736,7 +736,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   firstInput: {fileID: 0}
-  submitButton: {fileID: 0}
 --- !u!114 &74024523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -965,7 +964,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   firstInput: {fileID: 0}
-  submitButton: {fileID: 0}
 --- !u!114 &115650725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1258,7 +1256,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   firstInput: {fileID: 0}
-  submitButton: {fileID: 0}
 --- !u!114 &257929329
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3218,10 +3215,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 1753578535}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnDown: {fileID: 699779238}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
@@ -3395,10 +3392,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 1133519642}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnDown: {fileID: 1619592573}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1

--- a/Assets/Scripts/ChangeInput.cs
+++ b/Assets/Scripts/ChangeInput.cs
@@ -7,27 +7,36 @@ using UnityEngine.EventSystems;
 public class ChangeInput : MonoBehaviour {
     EventSystem system;
     public Selectable firstInput;
-    public Button submitButton;
 
-    void Start() {
+    void Start()
+    {
         system = EventSystem.current;
-        firstInput.Select();
+        if (firstInput != null)
+        {
+            firstInput.Select();
+        }
     }
 
     void Update() {
-        if (Input.GetKeyDown(KeyCode.Tab) && Input.GetKey(KeyCode.LeftShift)) {
-            Selectable previous = system.currentSelectedGameObject.GetComponent<Selectable>().FindSelectableOnUp();
-            if (previous != null) {
-                previous.Select();
+        if (system.currentSelectedGameObject != null) {
+            if (Input.GetKeyDown(KeyCode.Tab) && Input.GetKey(KeyCode.LeftShift)) {
+                Selectable previous = system.currentSelectedGameObject.GetComponent<Selectable>().FindSelectableOnUp();
+                if (previous != null) {
+                    previous.Select();
+                }
             }
-        } else if (Input.GetKeyDown(KeyCode.Tab)) {
-            Selectable next = system.currentSelectedGameObject.GetComponent<Selectable>().FindSelectableOnDown();
-            if (next != null) {
-                next.Select();  
+            else if (Input.GetKeyDown(KeyCode.Tab)) {
+                Selectable next = system.currentSelectedGameObject.GetComponent<Selectable>().FindSelectableOnDown();
+                if (next != null)  {
+                    next.Select();
+                }
             }
-        } else if (Input.GetKeyDown(KeyCode.Return)) {
-            submitButton.onClick.Invoke();
-            Debug.Log("Botón plsado");
+            else if (Input.GetKeyDown(KeyCode.Return))  {
+                Button button = system.currentSelectedGameObject.GetComponent<Button>();
+                if (button != null)  {
+                    button.onClick.Invoke();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Se han arreglado los errores al pulsar la tecla ENTER o TAB. Cuando no había ningún objeto seleccionado, estos daban una excepción de nulo.